### PR TITLE
Changing the installation module for Apache to package instead of dnf

### DIFF
--- a/apache.yml
+++ b/apache.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Ensure the httpd software is installed
-      ansible.builtin.dnf:
+      package:
         name: httpd
         state: present
     - name: Ensure the httpd service is enabled and started

--- a/apache.yml
+++ b/apache.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Ensure the httpd software is installed
-      package:
+      ansible.builtin.package:
         name: httpd
         state: present
     - name: Ensure the httpd service is enabled and started


### PR DESCRIPTION
The package module is a better general purpose choice, less potential maintenance further on...